### PR TITLE
fix for ie and edge

### DIFF
--- a/src/components/AxisLinear.js
+++ b/src/components/AxisLinear.js
@@ -84,9 +84,13 @@ function AxisLinear({
         position === positionTop || position === positionBottom
       const labelDims = Array(
         ...elRef.current.querySelectorAll('.tick text')
-      ).map(el => ({
-        ...el.getBoundingClientRect().toJSON()
-      }))
+      ).map(el => {
+        const rect = el.getBoundingClientRect()
+        return {
+          width: rect.width,
+          height: rect.height
+        }
+      })
 
       let smallestTickGap = 100000
       // This is just a ridiculously large tick spacing that would never happen (hopefully)


### PR DESCRIPTION
fixes https://github.com/react-tools/react-charts/issues/28

with polyfills for promise and similar, you it works on IE11, altough the charts are missing stuff like gridlines